### PR TITLE
MOEN-36447: Integrating `moe-android-sdk` in the MoEngage Kit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # mparticle-android-integration-moengage
 
+# Release Date
+
+## Release Version
+
+- Integrating `moe-android-sdk` in the Kit
+
 # 1.0.0
 
 ## 30-12-2024

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     implementation(appLibs.fcm)
     implementation(appLibs.installReferrer)
 
-    implementation(moengage.core)
     implementation(moengage.inapp)
     implementation(moengageInternal.kotlinStdLib)
 }

--- a/moengage-kit/build.gradle.kts
+++ b/moengage-kit/build.gradle.kts
@@ -51,8 +51,8 @@ android {
 }
 
 dependencies {
+    api(moengage.core)
     compileOnly(libs.mParticleAndroidKitBase)
-    compileOnly(moengage.core)
 
     testImplementation(moengage.core)
     testImplementation(libs.mParticleAndroidKitBase)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             from("com.moengage:android-dependency-catalog-internal:2.1.1")
         }
         create("moengage") {
-            from("com.moengage:android-dependency-catalog:4.5.2")
+            from("com.moengage:android-dependency-catalog:4.5.3")
         }
         create("appLibs") {
             from(files("./gradle/appLibs.versions.toml"))


### PR DESCRIPTION
### Jira Ticket
https://moengagetrial.atlassian.net/browse/MOEN-36447

### Description
Integrating `moe-android-sdk` in the MoEngage Kit.