### PR TITLE
MOEN-40576: Identifier cache migration to constant field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # mparticle-android-integration-moengage
+
+# Release Date
+
+## Release Version
+
+- [patch] Replaced the hard coded string mapping in `Cache` for identifier with exposed constant from `moe-android-sdk`
+
 # 25-09-2025
 
 ## 2.0.1

--- a/moengage-kit/src/main/java/com/moengage/mparticle/kits/internal/Cache.kt
+++ b/moengage-kit/src/main/java/com/moengage/mparticle/kits/internal/Cache.kt
@@ -12,6 +12,9 @@
  */
 package com.moengage.mparticle.kits.internal
 
+import com.moengage.core.USER_IDENTIFIER_EMAIL
+import com.moengage.core.USER_IDENTIFIER_MOBILE
+import com.moengage.core.USER_IDENTIFIER_UID
 import com.mparticle.MParticle.IdentityType
 
 /**
@@ -24,10 +27,10 @@ internal object Cache {
     /** Default identity mapping */
     private var identityMapping =
         mutableMapOf(
-            IdentityType.Alias to "uid",
-            IdentityType.CustomerId to "uid",
-            IdentityType.Email to "u_em",
-            IdentityType.MobileNumber to "u_mb")
+            IdentityType.Alias to USER_IDENTIFIER_UID,
+            IdentityType.CustomerId to USER_IDENTIFIER_UID,
+            IdentityType.Email to USER_IDENTIFIER_EMAIL,
+            IdentityType.MobileNumber to USER_IDENTIFIER_MOBILE)
 
     /** Update the identity mapping with the provided mapping */
     fun setIdentityMapping(mapping: Map<IdentityType, String>) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             from("com.moengage:android-dependency-catalog-internal:3.0.0")
         }
         create("moengage") {
-            from("com.moengage:android-dependency-catalog:5.4.2")
+            from("com.moengage:android-dependency-catalog:6.0.1")
         }
         create("appLibs") {
             from(files("./gradle/appLibs.versions.toml"))


### PR DESCRIPTION
### Jira Ticket
https://moengagetrial.atlassian.net/browse/MOEN-40576

### Description
Replaced the hard-coded string mapping in `Cache` for the identifier with an exposed constant from `moe-android-sdk`